### PR TITLE
3 auto detect latis2 vs latis3

### DIFF
--- a/client/latis.py
+++ b/client/latis.py
@@ -2,9 +2,36 @@ import numpy
 import pandas as pd
 import requests
 import urllib.parse
+    
+
+def __datasetCanUseVersion(baseUrl, dataset, preferVersion2):
+    if preferVersion2:
+        try:
+            print("TRY V2")
+            instanceV2 = LatisInstance(baseUrl, False)
+            dsObj = instanceV2.getDataset(dataset)
+
+            return False
+        except:
+            print("[WARN]: " + dataset + " cannot be accessed through Latis version 3. Auto switching to version 2.")
+
+            return True
+    else:
+        try:
+            print("TRY V3")
+            instanceV3 = LatisInstance(baseUrl, True)
+            dsObj = instanceV3.getDataset(dataset)
+
+            return True
+        except:
+            print("[WARN]: " + dataset + " cannot be accessed through Latis version 2. Auto switching to version 3.")
+
+            return False
 
 
-def data(baseUrl, latis3, dataset, returnType, operations=[]):
+def data(baseUrl, dataset, returnType, operations=[], preferVersion2=False):
+    latis3 = __datasetCanUseVersion(baseUrl, dataset, preferVersion2)
+    print("Using Latis3:", latis3)
     instance = LatisInstance(baseUrl, latis3)
     dsObj = instance.getDataset(dataset)
     for o in operations:
@@ -16,7 +43,8 @@ def data(baseUrl, latis3, dataset, returnType, operations=[]):
     else:
         return None
 
-def download(baseUrl, latis3, dataset, filename, fileFormat, operations=[]):
+def download(baseUrl, dataset, filename, fileFormat, operations=[], preferVersion2=False):
+    latis3 = __datasetCanUseVersion(preferVersion2)
     instance = LatisInstance(baseUrl, latis3)
     dsObj = instance.getDataset(dataset)
     for o in operations:

--- a/client/latis.py
+++ b/client/latis.py
@@ -7,31 +7,28 @@ import urllib.parse
 def __datasetCanUseVersion(baseUrl, dataset, preferVersion2):
     if preferVersion2:
         try:
-            print("TRY V2")
             instanceV2 = LatisInstance(baseUrl, False)
             dsObj = instanceV2.getDataset(dataset)
 
             return False
         except:
-            print("[WARN]: " + dataset + " cannot be accessed through Latis version 3. Auto switching to version 2.")
+            print("[WARN]: " + dataset + " cannot be accessed through Latis version 2. Auto switching to version 3.")
 
             return True
     else:
         try:
-            print("TRY V3")
             instanceV3 = LatisInstance(baseUrl, True)
             dsObj = instanceV3.getDataset(dataset)
 
             return True
         except:
-            print("[WARN]: " + dataset + " cannot be accessed through Latis version 2. Auto switching to version 3.")
+            print("[WARN]: " + dataset + " cannot be accessed through Latis version 3. Auto switching to version 2.")
 
             return False
 
 
 def data(baseUrl, dataset, returnType, operations=[], preferVersion2=False):
     latis3 = __datasetCanUseVersion(baseUrl, dataset, preferVersion2)
-    print("Using Latis3:", latis3)
     instance = LatisInstance(baseUrl, latis3)
     dsObj = instance.getDataset(dataset)
     for o in operations:

--- a/client/latis.py
+++ b/client/latis.py
@@ -4,7 +4,7 @@ import requests
 import urllib.parse
     
 
-def __datasetCanUseVersion(baseUrl, dataset, preferVersion2):
+def __datasetWillUseVersion3(baseUrl, dataset, preferVersion2):
     if preferVersion2:
         try:
             instanceV2 = LatisInstance(baseUrl, False)
@@ -28,7 +28,7 @@ def __datasetCanUseVersion(baseUrl, dataset, preferVersion2):
 
 
 def data(baseUrl, dataset, returnType, operations=[], preferVersion2=False):
-    latis3 = __datasetCanUseVersion(baseUrl, dataset, preferVersion2)
+    latis3 = __datasetWillUseVersion3(baseUrl, dataset, preferVersion2)
     instance = LatisInstance(baseUrl, latis3)
     dsObj = instance.getDataset(dataset)
     for o in operations:
@@ -41,7 +41,7 @@ def data(baseUrl, dataset, returnType, operations=[], preferVersion2=False):
         return None
 
 def download(baseUrl, dataset, filename, fileFormat, operations=[], preferVersion2=False):
-    latis3 = __datasetCanUseVersion(preferVersion2)
+    latis3 = __datasetWillUseVersion3(preferVersion2)
     instance = LatisInstance(baseUrl, latis3)
     dsObj = instance.getDataset(dataset)
     for o in operations:

--- a/tests/example.py
+++ b/tests/example.py
@@ -24,7 +24,7 @@ def testShortcuts():
     print("Latis2 Numpy")
     testLatis2Np = latis.data(
         'https://lasp.colorado.edu/lisird/latis',
-        'cls_radio_flux_f8', 'NUMPY', operations=['time<0'], preferVersion2=False)
+        'cls_radio_flux_f8', 'NUMPY', operations=['time<0'], preferVersion2=False) # Will auto switch to latis 2
     print(testLatis2Np)
 
     print("Latis2 Pandas")
@@ -42,7 +42,7 @@ def testShortcuts():
     print("Latis3 Pandas")
     testLatis3Pd = latis.data(
         'https://lasp.colorado.edu/lisird/latis',
-        'sorce_mg_index', 'PANDAS', operations=['time<2452705'], preferVersion2=True)
+        'sorce_mg_index', 'PANDAS', operations=['time<2452705'], preferVersion2=True) # Dataset also exists on latis 2. Will not auto switch.
     print(testLatis3Pd)
 
 def testCore():

--- a/tests/example.py
+++ b/tests/example.py
@@ -23,26 +23,26 @@ def testShortcuts():
 
     print("Latis2 Numpy")
     testLatis2Np = latis.data(
-        'https://lasp.colorado.edu/lisird/latis', False,
-        'cls_radio_flux_f8', 'NUMPY', operations=['time<0'])
+        'https://lasp.colorado.edu/lisird/latis',
+        'cls_radio_flux_f8', 'NUMPY', operations=['time<0'], preferVersion2=False)
     print(testLatis2Np)
 
     print("Latis2 Pandas")
     testLatis2Pd = latis.data(
-        'https://lasp.colorado.edu/lisird/latis', False,
-        'cls_radio_flux_f8', 'PANDAS', operations=['time<0'])
+        'https://lasp.colorado.edu/lisird/latis',
+        'cls_radio_flux_f8', 'PANDAS', operations=['time<0'], preferVersion2=True)
     print(testLatis2Pd)
 
     print("Latis3 Numpy")
     testLatis3Np = latis.data(
-        'https://lasp.colorado.edu/lisird/latis', True,
+        'https://lasp.colorado.edu/lisird/latis',
         'sorce_mg_index', 'NUMPY', operations=['time<2452705'])
     print(testLatis3Np)
 
     print("Latis3 Pandas")
     testLatis3Pd = latis.data(
-        'https://lasp.colorado.edu/lisird/latis', True,
-        'sorce_mg_index', 'PANDAS', operations=['time<2452705'])
+        'https://lasp.colorado.edu/lisird/latis',
+        'sorce_mg_index', 'PANDAS', operations=['time<2452705'], preferVersion2=True)
     print(testLatis3Pd)
 
 def testCore():


### PR DESCRIPTION
For `data` function added a `preferVersion2` parameter replacing `latis3` bool.

latis3 is now internally determined via `__datasetCanUseVersion` which checks to see if the chosen dataset is available on the preferred version. If it is not it will auto switch to v2 or v3.

"auto-switching" versions was not implemented on LatisInstance objects themselves because datasets are undetermined at the time of creation. It would be possible to switch the latis version at the dataset level however this maintains a method of direct control over inserting `dap2` vs `dap` to the url. (open for discussion).

preferVersion2 defaults to False (latis3)